### PR TITLE
bootloader: fix crash with empty lines in /cache/recovery/command

### DIFF
--- a/bootloader.cpp
+++ b/bootloader.cpp
@@ -389,6 +389,7 @@ get_args(int *argc, char ***argv) {
     if (*argc <= 1) {
         FILE *fp = fopen(COMMAND_FILE, "r");
         if (fp != NULL) {
+            char *token;
             char *argv0 = (*argv)[0];
             *argv = (char **) malloc(sizeof(char *) * MAX_ARGS);
             (*argv)[0] = argv0;  // use the same program name
@@ -396,12 +397,17 @@ get_args(int *argc, char ***argv) {
             char buf[MAX_ARG_LENGTH];
             for (*argc = 1; *argc < MAX_ARGS; ++*argc) {
                 if (!fgets(buf, sizeof(buf), fp)) break;
-                (*argv)[*argc] = strdup(strtok(buf, "\r\n"));  // Strip newline.
+                token = strtok(buf, "\r\n");
+                if (token != NULL) {
+                    (*argv)[*argc] = strdup(token);  // Strip newline.
+                } else {
+                    --*argc;
+                }
             }
 
             fflush(fp);
-		    if (ferror(fp)) LOGE("Error in %s\n(%s)\n", COMMAND_FILE, strerror(errno));
-		    fclose(fp);
+            if (ferror(fp)) LOGE("Error in %s\n(%s)\n", COMMAND_FILE, strerror(errno));
+            fclose(fp);
             LOGI("Got arguments from %s\n", COMMAND_FILE);
         }
     }


### PR DESCRIPTION
original fix from commit 93ffa7579cd75d1bdb2d124aa5cc5f8b6025e3d8
copied to our code.

Also fixed a whitespace issue in the same code block.

Change-Id: I6396803659c6880cde4f2b2ef08efab5721c215d