### PR TITLE
twrpTar: fix segfault after encrypted backups

### DIFF
--- a/twrp-functions.cpp
+++ b/twrp-functions.cpp
@@ -125,19 +125,19 @@ int TWFunc::Wait_For_Child(pid_t pid, int *status, string Child_Name) {
 	rc_pid = waitpid(pid, status, 0);
 	if (rc_pid > 0) {
 		if (WIFSIGNALED(*status)) {
-			LOGINFO("%s process ended with signal: %d\n", Child_Name.c_str(), WTERMSIG(*status)); // Seg fault or some other non-graceful termination
+			LOGERR("%s process ended with signal: %d\n", Child_Name.c_str(), WTERMSIG(*status)); // Seg fault or some other non-graceful termination
 			return -1;
 		} else if (WEXITSTATUS(*status) == 0) {
 			LOGINFO("%s process ended with RC=%d\n", Child_Name.c_str(), WEXITSTATUS(*status)); // Success
 		} else {
-			LOGINFO("%s process ended with ERROR=%d\n", Child_Name.c_str(), WEXITSTATUS(*status)); // Graceful exit, but there was an error
+			LOGERR("%s process ended with ERROR=%d\n", Child_Name.c_str(), WEXITSTATUS(*status)); // Graceful exit, but there was an error
 			return -1;
 		}
 	} else { // no PID returned
 		if (errno == ECHILD)
-			LOGINFO("%s no child process exist\n", Child_Name.c_str());
+			LOGERR("%s no child process exist\n", Child_Name.c_str());
 		else {
-			LOGINFO("%s Unexpected error\n", Child_Name.c_str());
+			LOGERR("%s Unexpected error %d\n", Child_Name.c_str(), errno);
 			return -1;
 		}
 	}

--- a/twrpTar.cpp
+++ b/twrpTar.cpp
@@ -118,8 +118,8 @@ int twrpTar::createTarFork(const unsigned long long *overall_size, const unsigne
 			LOGINFO("Using encryption\n");
 			DIR* d;
 			struct dirent* de;
-			unsigned long long regular_size = 0, encrypt_size = 0, target_size = 0, core_count = 1, total_size;
-			unsigned enc_thread_id = 1, regular_thread_id = 0, i, start_thread_id = 1;
+			unsigned long long regular_size = 0, encrypt_size = 0, target_size = 0, total_size;
+			unsigned enc_thread_id = 1, regular_thread_id = 0, i, start_thread_id = 1, core_count = 1;
 			int item_len, ret, thread_error = 0;
 			std::vector<TarListStruct> RegularList;
 			std::vector<TarListStruct> EncryptList;
@@ -134,7 +134,7 @@ int twrpTar::createTarFork(const unsigned long long *overall_size, const unsigne
 			core_count = sysconf(_SC_NPROCESSORS_CONF);
 			if (core_count > 8)
 				core_count = 8;
-			LOGINFO("   Core Count      : %llu\n", core_count);
+			LOGINFO("   Core Count      : %u\n", core_count);
 			Archive_Current_Size = 0;
 
 			d = opendir(tardir.c_str());
@@ -223,7 +223,7 @@ int twrpTar::createTarFork(const unsigned long long *overall_size, const unsigne
 			}
 			closedir(d);
 			if (enc_thread_id != core_count) {
-				LOGERR("Error dividing up threads for encryption, %i threads for %i cores!\n", enc_thread_id, core_count);
+				LOGERR("Error dividing up threads for encryption, %u threads for %u cores!\n", enc_thread_id, core_count);
 				if (enc_thread_id > core_count) {
 					close(progress_pipe[1]);
 					_exit(-1);
@@ -311,7 +311,7 @@ int twrpTar::createTarFork(const unsigned long long *overall_size, const unsigne
 						_exit(-1);
 					} else {
 						LOGINFO("Joined thread %i.\n", i);
-						ret = *((int *)thread_return);
+						ret = (int)(intptr_t)thread_return;
 						if (ret != 0) {
 							thread_error = 1;
 							LOGERR("Thread %i returned an error %i.\n", i, ret);
@@ -545,7 +545,7 @@ int twrpTar::extractTarFork(const unsigned long long *overall_size, unsigned lon
 							_exit(-1);
 						} else {
 							LOGINFO("Joined thread %i.\n", i);
-							ret = *((int *)thread_return);
+							ret = (int)(intptr_t)thread_return;
 							if (ret != 0) {
 								thread_error = 1;
 								LOGERR("Thread %i returned an error %i.\n", i, ret);


### PR DESCRIPTION
also use unsigned int for core_count instead of unsigned long long.
I'll change it back when 4-billion-core devices are common.

PS2
- cast return value via intptr_t (may be important for 64 bit platforms)
- output errors from TWFunc::Wait_For_Child to console

Change-Id: I04158daa0b64e44d68e179d626a83d81cf5d49f7